### PR TITLE
Add `fs` requirement

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,8 @@
 var loaderUtils = require('loader-utils'),
   _ = require('lodash'),
   path = require('path'),
-  helper = require('./src/helper');
+  helper = require('./src/helper'),
+  fs = require('fs');
 
 var defaultOptions = {
   test: /\.vue\./,
@@ -19,7 +20,7 @@ module.exports = function (content, map) {
   var inputFile = map.file || path.basename(this.resourcePath),
     options = _.assign({}, _.cloneDeep(defaultOptions), loaderOptions),
     dirPath = this.context,
-    fileNames = this.fs.readdirSync(dirPath).filter(function (file) {
+    fileNames = fs.readdirSync(dirPath).filter(function (file) {
       return !file.match(/^\./);
     });
 


### PR DESCRIPTION
A clean install of vue cli 3.5.1 fails with the `npm run build` command. `this.fs` is said to be undefined.

Steps to reproduce:
- `npm install -g @vue/cli` 
- `npm install -D vue-separate-files-webpack-loader`
- `npm run build`